### PR TITLE
Make the TCP client more conducive to the async pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ From here, you can filter devices as desired, and use the functions on the CyncD
 
 ## Setting a State Change Callback
 If you would like to specify a callback function to run whenever device states change, you may provide one to the Cync object.  
-The update_data parameter is a JSON object. The key is the device ID, and the value is the CyncDevice object with its new state set.
+The update_data parameter is a JSON object. The key is the device ID, and the value is the CyncDevice object with its new state set.  
+The callback function may be either synchronous or asynchronous.
 ```
 def my_callback(update_data: dict[int, CyncDevice]):
     # Handle updated data

--- a/pycync/cync.py
+++ b/pycync/cync.py
@@ -112,6 +112,6 @@ class Cync:
 
         device_storage.set_user_homes(self._auth.user.user_id, homes)
 
-    def shut_down(self):
+    async def shut_down(self):
         """Shut down the command client instance and close its associated connections."""
-        self._command_client.shut_down()
+        await self._command_client.shut_down()

--- a/pycync/devices/device_types.py
+++ b/pycync/devices/device_types.py
@@ -11,6 +11,7 @@ List last updated from Android app version 6.20.0.54634-60b11b1f5
 
 from enum import Enum
 
+
 class DeviceType(Enum):
     LIGHT = "Light"
     INDOOR_LIGHT_STRIP = "IndoorLightStrip"
@@ -32,6 +33,13 @@ class DeviceType(Enum):
     THERMOSTAT = "Thermostat"
     CAMERA = "Camera"
     UNKNOWN = "Unknown"
+
+    @classmethod
+    def is_light(cls, device_type_code: int) -> bool:
+        resolved_type = DEVICE_TYPES.get(device_type_code, DeviceType.UNKNOWN)
+        return resolved_type in {cls.LIGHT, cls.INDOOR_LIGHT_STRIP, cls.OUTDOOR_LIGHT_STRIP, cls.NEON_LIGHT_STRIP,
+                                 cls.CAFE_STRING_LIGHTS, cls.DOWNLIGHT, cls.UNDERCABINET_FIXTURES, cls.LIGHT_TILE}
+
 
 DEVICE_TYPES = {
     # FullColorStripGen1Standalone

--- a/pycync/tcp/command_client.py
+++ b/pycync/tcp/command_client.py
@@ -34,10 +34,10 @@ class CommandClient:
     def start_connection(self):
         self._tcp_manager = TcpManager(self._user, self.on_message_received)
 
-    def on_message_received(self, parsed_message: ParsedMessage):
+    async def on_message_received(self, parsed_message: ParsedMessage):
         match parsed_message.message_type:
             case MessageType.LOGIN.value:
-                self.probe_devices()
+                await self.probe_devices()
             case MessageType.PROBE.value if parsed_message.version != 0:
                 devices_in_home = device_storage.get_associated_home_devices(self._user.user_id,
                                                                              parsed_message.device_id)
@@ -45,17 +45,13 @@ class CommandClient:
                 device.set_wifi_connected(True)
                 self._device_statuses_updated = True
             case MessageType.SYNC.value:
-                callback = device_storage.get_user_device_callback(self._user.user_id)
-                if callback is not None:
-                    callback(parsed_message.data)
+                await self._send_update_to_listener(parsed_message.data)
             case MessageType.PIPE.value:
                 if parsed_message.command_code == PipeCommandCode.QUERY_DEVICE_STATUS_PAGES.value:
-                    callback = device_storage.get_user_device_callback(self._user.user_id)
-                    if callback is not None:
-                        callback(parsed_message.data)
+                    await self._send_update_to_listener(parsed_message.data)
 
-    def probe_devices(self):
-        self._tcp_manager.probe_devices(device_storage.get_flattened_devices(self._user.user_id))
+    async def probe_devices(self):
+        await self._tcp_manager.probe_devices(device_storage.get_flattened_devices(self._user.user_id))
 
     async def update_mesh_devices(self):
         """Get new device state."""
@@ -66,13 +62,13 @@ class CommandClient:
             hub_device = await self._fetch_hub_device(home)
             hub_devices.append(hub_device)
 
-        self._tcp_manager.update_mesh_devices(hub_devices)
+        await self._tcp_manager.update_mesh_devices(hub_devices)
 
     async def set_power_state(self, controllable: CyncControllable, is_on: bool):
         """Set device(s) to either on or off."""
         hub_device = await self._fetch_hub_device(controllable.parent_home)
 
-        self._tcp_manager.set_power_state(hub_device, controllable.mesh_reference_id, is_on)
+        await self._tcp_manager.set_power_state(hub_device, controllable.mesh_reference_id, is_on)
 
     async def set_brightness(self, controllable: CyncControllable, brightness: int):
         """Sets the brightness. Must be between 0 and 100 inclusive."""
@@ -81,7 +77,7 @@ class CommandClient:
 
         hub_device = await self._fetch_hub_device(controllable.parent_home)
 
-        self._tcp_manager.set_brightness(hub_device, controllable.mesh_reference_id, brightness)
+        await self._tcp_manager.set_brightness(hub_device, controllable.mesh_reference_id, brightness)
 
     async def set_color_temp(self, controllable: CyncControllable, color_temp: int):
         """
@@ -93,7 +89,7 @@ class CommandClient:
 
         hub_device = await self._fetch_hub_device(controllable.parent_home)
 
-        self._tcp_manager.set_color_temp(hub_device, controllable.mesh_reference_id, color_temp)
+        await self._tcp_manager.set_color_temp(hub_device, controllable.mesh_reference_id, color_temp)
 
     async def set_rgb(self, controllable: CyncControllable, rgb: tuple[int, int, int]):
         """Sets the RGB color. Each color must be between 0 and 255 inclusive."""
@@ -102,10 +98,18 @@ class CommandClient:
 
         hub_device = await self._fetch_hub_device(controllable.parent_home)
 
-        self._tcp_manager.set_rgb(hub_device, controllable.mesh_reference_id, rgb)
+        await self._tcp_manager.set_rgb(hub_device, controllable.mesh_reference_id, rgb)
 
-    def shut_down(self):
-        self._tcp_manager.shut_down()
+    async def shut_down(self):
+        await self._tcp_manager.shut_down()
+
+    async def _send_update_to_listener(self, updated_data):
+        callback = device_storage.get_user_device_callback(self._user.user_id)
+        if callback is not None:
+            if asyncio.iscoroutinefunction(callback):
+                await callback(updated_data)
+            else:
+                callback(updated_data)
 
     async def _fetch_hub_device(self, home: CyncHome) -> CyncDevice:
         """

--- a/pycync/tcp/packet_parser.py
+++ b/pycync/tcp/packet_parser.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 import struct
 
 from ..devices import device_storage
+from ..devices.device_types import DeviceType
 from .packet import ParsedMessage, ParsedInnerFrame, MessageType, PipeCommandCode, generate_checksum
 from pycync.devices.capabilities import DEVICE_CAPABILITIES, CyncCapability
 
@@ -63,7 +64,8 @@ def _parse_sync_packet(packet: bytearray, is_response, version, user_id) -> Pars
             mesh_id = packet[0]
             try:
                 resolved_device = next(device for device in device_list if device.isolated_mesh_id == mesh_id)
-                resolved_device.update_state(bool(packet[1]), packet[2], packet[3], (packet[4], packet[5], packet[6]))
+                if DeviceType.is_light(resolved_device.device_type):
+                    resolved_device.update_state(bool(packet[1]), packet[2], packet[3], (packet[4], packet[5], packet[6]))
             except StopIteration as ex:
                 raise ValueError("Unable to resolve device ID for mesh ID: {}".format(mesh_id)) from ex
 
@@ -134,7 +136,8 @@ def _parse_device_status_pages_command(data_bytes: bytearray, device_list) -> di
 
         try:
             resolved_device = next(device for device in device_list if device.isolated_mesh_id == mesh_id)
-            resolved_device.update_state(bool(is_on), brightness, color_mode, rgb, bool(is_online))
+            if DeviceType.is_light(resolved_device.device_type):
+                resolved_device.update_state(bool(is_on), brightness, color_mode, rgb, bool(is_online))
         except StopIteration as ex:
             raise ValueError("Unable to resolve device ID for mesh ID: {}".format(mesh_id)) from ex
 


### PR DESCRIPTION
The TCP client was previously using a separate thread to prevent blocking while waiting for TCP data to arrive.

This code has been modified to better use async tasks, so that it can now run in the main thread and event loop without blocking. This now also allows update callbacks to be async as well as synchronous.