### PR TITLE
raise minimum Python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 license = { text="GPL-3.0-or-later" }
 readme = "README.md"
-requires-python = ">=3.9.0"
+requires-python = ">=3.13.0"
 dependencies = [
     "aiohttp>=3",
 ]


### PR DESCRIPTION
`asyncio.QueueShutDown` was only added in Python 3.13